### PR TITLE
Add a couple a new feature to xibcolor

### DIFF
--- a/xibcolor
+++ b/xibcolor
@@ -52,6 +52,13 @@ def listcolors(dom):
         print "White: " + white
       hexv = argbtohex(float(alpha), float(white), float(white), float(white))
       allcolors.append(hexv)
+    elif colsp == "custom" and customColorSpace == "calibratedWhite":
+      alpha = node.getAttribute('alpha')
+      white = node.getAttribute('white')
+      if debugMode:
+        print "White: " + white
+      hexv = argbtohex(float(alpha), float(white), float(white), float(white))
+      allcolors.append(hexv)
     elif colsp == "custom" and customColorSpace == "sRGB":
       red = node.getAttribute('red')
       green = node.getAttribute('green')
@@ -68,7 +75,7 @@ def listcolors(dom):
       if debugMode:
         print "colorSpace: " + colsp
         print "colorSpace: " + customColorSpace
-        print "keys: " + node.attributes.keys()
+        print "keys: " + ", ".join(node.attributes.keys())
   if debugMode:
     print "---- [Extracted Colors]"
   for col in set(allcolors):

--- a/xibcolor
+++ b/xibcolor
@@ -6,8 +6,11 @@
 import sys
 from xml.dom.minidom import parse
 
-
 # <color key="titleColor" red="0.30196079609999998" green="0.30196079609999998" blue="0.30196079609999998" alpha="1" colorSpace="calibratedRGB"/>
+# <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+# <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+
+debugMode = True
 
 def clamp(x): 
     return max(0, min(int(round(x)), 255))
@@ -27,15 +30,51 @@ def listcolors(dom):
   allcolors = []
   for node in dom.getElementsByTagName('color'):  # visit every node <bar />
     colsp = node.getAttribute('colorSpace')
+    customColorSpace = node.getAttribute('customColorSpace')
+    if debugMode:
+      print "---- [Debug]"
     if colsp == 'calibratedRGB' or colsp == 'deviceRGB':
       red = node.getAttribute('red')
       green = node.getAttribute('green')
       blue = node.getAttribute('blue')
       alpha = node.getAttribute('alpha')
+      if debugMode:
+        print "Red: " + red
+        print "Green: " + green
+        print "Blue: " + blue
+        print "Alpha: " + alpha
       hexv = argbtohex(float(alpha), float(red), float(green), float(blue))
       allcolors.append(hexv)
+    elif colsp == "calibratedWhite":
+      alpha = node.getAttribute('alpha')
+      white = node.getAttribute('white')
+      if debugMode:
+        print "White: " + white
+      hexv = argbtohex(float(alpha), float(white), float(white), float(white))
+      allcolors.append(hexv)
+    elif colsp == "custom" and customColorSpace == "sRGB":
+      red = node.getAttribute('red')
+      green = node.getAttribute('green')
+      blue = node.getAttribute('blue')
+      alpha = node.getAttribute('alpha')
+      if debugMode:
+        print "Red: " + red
+        print "Green: " + green
+        print "Blue: " + blue
+        print "Alpha: " + alpha
+      hexv = argbtohex(float(alpha), float(red), float(green), float(blue))
+      allcolors.append(hexv)
+    else:
+      if debugMode:
+        print "colorSpace: " + colsp
+        print "colorSpace: " + customColorSpace
+        print "keys: " + node.attributes.keys()
+  if debugMode:
+    print "---- [Extracted Colors]"
   for col in set(allcolors):
     print col
+  if debugMode:
+    print "----"
 
 def replacecolor(dom, fromcol, tocol):
   didreplace = False
@@ -74,6 +113,8 @@ if len(sys.argv) == 2 and sys.argv[1] == '-h':
   usage()
 
 xibOrStoryboard = sys.argv[1]
+if debugMode:
+  print "Filename: " + xibOrStoryboard
 
 dom = parse(xibOrStoryboard)
 
@@ -105,4 +146,3 @@ elif len(sys.argv) == 4:
       ofile.write(dom.toxml().encode('utf-8'))
 else:
   usage()
-

--- a/xibcolor
+++ b/xibcolor
@@ -82,6 +82,7 @@ def listcolors(dom):
     print col
   if debugMode:
     print "----"
+  return allcolors
 
 def replacecolor(dom, fromcol, tocol):
   didreplace = False
@@ -104,11 +105,30 @@ def replacecolor(dom, fromcol, tocol):
         didreplace = True
   return didreplace
 
+
+def generateAllColors(inputFile, outputFile):
+  with open(inputFile) as f:
+    content = f.readlines()
+  cleanedContent = [x.strip() for x in content]
+  # print cleanedContent
+  outputColors = []
+  for aFile in cleanedContent:
+    dom = parse(aFile)
+    if dom is None:
+      print "Cannot open %s" % xibOrStoryboard
+      sys.exit()
+    outputColors.extend(listcolors(dom))
+  outputFileHandler = open(outputFile, 'w')
+  for line in set(outputColors):
+    outputFileHandler.write("%s\n" % line)
+
+
 def usage():
   print "usage:"
-  print "xibcolor file [-l|replacements|[\"#fromcolor\" \"#tocolor\"]]"
+  print "xibcolor file [-l | replacements | [\"#fromcolor\" \"#tocolor\"] | -j filelist.txt output.txt]"
   print "file          a .storyboard or xib in new XML format"
   print "-l            list colors present in the file"
+  print "-j            export all the colors find in the xibs and storyboard from the filelist et into a single file"
   print "replacements  a file consisting of pairs of hex-coded from->to colors"
   print "#color        a pair of colors to replace" 
   sys.exit(0)
@@ -119,37 +139,40 @@ if len(sys.argv) == 1:
 if len(sys.argv) == 2 and sys.argv[1] == '-h':
   usage()
 
-xibOrStoryboard = sys.argv[1]
-if debugMode:
-  print "Filename: " + xibOrStoryboard
-
-dom = parse(xibOrStoryboard)
-
-if dom is None:
-  print "Cannot open %s" % xibOrStoryboard
-  usage()
-
-if len(sys.argv) == 3 and sys.argv[2] == '-l':
-  listcolors(dom)
-elif len(sys.argv) == 3 and sys.argv[2] != '-l':
-  with open(sys.argv[2], 'r') as colors:
-    countOfReplacements = 0
-    for line in colors:
-      if len(line) > 0:
-        (fcol,tocol,) = line.split()
-	countOfReplacements += replacecolor(dom, fcol, tocol)
-    if countOfReplacements > 0:
-      with open(sys.argv[1], 'w') as ofile:
-        ofile.write(dom.toxml().encode('utf-8'))
-      print "%d colors replaced in %s" % (countOfReplacements, xibOrStoryboard)
-    else:
-      print "No colors were replaced in %s" % xibOrStoryboard
-elif len(sys.argv) == 4:
-  fromcol = sys.argv[2]
-  tocol = sys.argv[3]
-  print "From: %s to: %s" % (fromcol, tocol)
-  if replacecolor(dom, fromcol, tocol): 
-    with open('out.storyboard', 'w') as ofile:
-      ofile.write(dom.toxml().encode('utf-8'))
+if len(sys.argv) == 4 and sys.argv[1] == '-j':
+  generateAllColors(sys.argv[2], sys.argv[3])
 else:
-  usage()
+  xibOrStoryboard = sys.argv[1]
+  if debugMode:
+    print "Filename: " + xibOrStoryboard
+    
+  dom = parse(xibOrStoryboard)
+  if dom is None:
+    print "Cannot open %s" % xibOrStoryboard
+    usage()
+
+  if len(sys.argv) == 3 and sys.argv[2] == '-l':
+    listcolors(dom)
+  elif len(sys.argv) == 3 and sys.argv[2] != '-l':
+    with open(sys.argv[2], 'r') as colors:
+      countOfReplacements = 0
+      for line in colors:
+        if len(line) > 0:
+          (fcol,tocol,) = line.split()
+      countOfReplacements += replacecolor(dom, fcol, tocol)
+      if countOfReplacements > 0:
+        with open(sys.argv[1], 'w') as ofile:
+          ofile.write(dom.toxml().encode('utf-8'))
+        print "%d colors replaced in %s" % (countOfReplacements, xibOrStoryboard)
+      else:
+        print "No colors were replaced in %s" % xibOrStoryboard
+  elif len(sys.argv) == 4:
+    fromcol = sys.argv[2]
+    tocol = sys.argv[3]
+    print "From: %s to: %s" % (fromcol, tocol)
+    if replacecolor(dom, fromcol, tocol):
+      with open('out.storyboard', 'w') as ofile:
+        ofile.write(dom.toxml().encode('utf-8'))
+  else:
+    usage()
+ 

--- a/xibcolor
+++ b/xibcolor
@@ -10,7 +10,7 @@ from xml.dom.minidom import parse
 # <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
 # <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
 
-debugMode = True
+debugMode = False
 
 def clamp(x): 
     return max(0, min(int(round(x)), 255))


### PR DESCRIPTION
Hi, **Thanks** for your great script it made my day 👍 

I'm working to create a small color palette for the app I'm working on and your tools are helping me a lot.

_I'm not a Python developer by any means._

I tried to add support for new color spaces:
- **calibratedWhite**
- **custom** and with **customColorSpace**=**sRGB**
- **custom** and with **customColorSpace**=**calibratedWhite**

I add a new mode `-j` that allows the user to export all the colors from a list of xibs and storyboard into a single file.

Exemple usage `./xibcolor -j filelist.txt color.txt`

The `filelist.txt` should look like this

```
/toto/tata/titi/file.xib
/toto/tata/titi/file1.xib
/toto/tata/titi/file2.xib
/toto/tata/titi/file3.xib
/toto/tata/titi/file4.xib
/toto/tata/titi/file.storyboard
/toto/tata/titi/file2.storyboard
/toto/tata/titi/file3.storyboard
```
 
The `color.txt` will look like this

```
#b3ffffff
#bf2b2b2b
#cc000000
#ccffffff
#e60c80f2
#ff000000
#ff0078ff
#ff007aff
#ff0080ff
#ff0082f5
#ff057aff
#ff0c6bff
#ff0d7aff
#ff0e7cff
#ff1065cc
#ff157dfb
#ff1a1a1a
#ff1b1b1b
#ff1d87ff
#ff282c32
#ff303030
#ff324f85
#ff333333
#ff484848
#ff4a5054
#ff555555
#ff5929c1
#ff666666
#ff6f7179
#ff767676
```

Thanks for your script!